### PR TITLE
Feed as a service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cache/
+config.json

--- a/README.md
+++ b/README.md
@@ -1,43 +1,38 @@
-Anwendungen
+FOSSASIA Feed Merger
 ===========
+RSS feed merger for FOSSASIA API communities
 
-Freifunk Community Map
-----------------------
+[![Join the chat at https://gitter.im/fossasia/api.fossasia.net](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fossasia/api.fossasia.net?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-Ein Beispiel gibt es hier: http://weimarnetz.de/ffmap/map.html
+## Setup
 
-Freifunk Community Feed Merger
-------------------------------
+* Clone the repo :
 
-Blogfeeds werden hier zusammengefast: http://weimarnetz.de/fffeed/feed.php
+	```sh
+	git clone https://github.com/fossasia/feed.api.fossasia.net.git
+	cd feed.api.fossasia.net
+	```
+
+* Create `config.json` from `config.json.sample`, and modify it as you need.
+
+	```sh
+	cp config.json.sample config.json
+	```
+
+* Create a `cache` folder to store cached feeds
+
+* Run `feed.php` (or access it from a php web server)
+
+	```sh
+	php feed.php
+	```
 
 
-Entstehung
-==========
 
-Zum Wireless Community Weekend 2013 in Berlin fand ein ersten Treffen
-zum Relaunch unserer Website freifunk.net statt. Dabei kam auch die
-Frage auf, wie man die einzelnen Freifunkcommunities am besten
-präsentieren kann, ohne alle Daten zentral zu erfassen und zudem den
-Communities eine einfache Möglichkeit zu bieten, eigene Daten selbst
-aktuell zu halten.
+## History
 
-In Anlehnung an die Hackerspaces API (http://hackerspaces.nl/spaceapi/)
-wurde die Idee einer Freifunk API geboren: Jede Community stellt ihre
-Daten in einem definierten Format an einer ihr zugänglichen Stelle
-(Webspace, Wiki, Webserver) bereit und trägt sich in das Verzeichnis
-ein. Das Verzeichnis besteht lediglich aus einer Zuordnung von
-Communitynamen und URL zu den den bereitgestellten Daten. Die erste
-Anwendung soll eine Karte mit darin angezeigten Freifunkcommunities
-sein, um Besuchern und Interessierten einen Überblick zu geben und
-lokale Ansprechpartner zu vermitteln.
-
-Die Freifunk API soll die Metadaten der Communities dezentral sammeln und anderen Nutzern zur Verfügung stellen. Die API ist nicht zu verwechseln mit einer Datenbank für Freifunkknoten oder als Verzeichnis von Firmwareeintellungen einzelner Communities.
-
-Weitere Informationen zur API sind in einem Blogartikel unter http://blog.freifunk.net/2013/die-neue-freifunk-api-aufruf-zum-mitmachen zusammengefasst.
-
-History
-=======
+Our goal is to collect information about Open Source Communities and Hackspaces all over Asia. This information will be used to aggregate contact data, locations, news feeds and events.
+We adopted this API from the Hackerspaces and Freifunk API, invented years before to collect decentralized data.
 
 At the Wireless Community Weekend 2013 in Berlin there was a first meeting to relaunch freifunk.net. To represent local communities without collecting and storing data centrally, a way had to be found. Another requirement was to enable local communities to keep their data up to date easily.
 
@@ -45,4 +40,6 @@ Based on the Hackerspaces API (http://hackerspaces.nl/spaceapi/) the idea of the
 
 The freifunk API is designed to collect metadata of communities in a decentral way and make it available to other users. It's not designated to be a freifunk node database or a directory of individual community firmware settings.
 
+## Contribute
 
+Issues & Pull Requests are highly appreciated. Check out our issues for contribution opportunities. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 FOSSASIA Feed Merger
 ===========
-RSS feed merger for FOSSASIA API communities
+RSS blog feed merger for FOSSASIA API communities
 
 [![Join the chat at https://gitter.im/fossasia/api.fossasia.net](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fossasia/api.fossasia.net?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -39,6 +39,8 @@ At the Wireless Community Weekend 2013 in Berlin there was a first meeting to re
 Based on the Hackerspaces API (http://hackerspaces.nl/spaceapi/) the idea of the freifunk API was born: Each community provides its data in a well defined format, hosted on their places (web space, wiki, web servers) and contributes a link to the directory. This directory only consists of the name and an url per community. First services supported by our freifunk API are the global community map and a community feed aggregator.
 
 The freifunk API is designed to collect metadata of communities in a decentral way and make it available to other users. It's not designated to be a freifunk node database or a directory of individual community firmware settings.
+
+[FOSSASIA API repo](https://github.com/fossasia/api.fossasia.net)
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -42,3 +42,6 @@ The freifunk API is designed to collect metadata of communities in a decentral w
 
 [FOSSASIA API repo](https://github.com/fossasia/api.fossasia.net)
 
+## Contribute
+
+Issues & Pull Requests are highly appreciated. Check out our issues for contribution opportunities.

--- a/config.json.sample
+++ b/config.json.sample
@@ -1,0 +1,3 @@
+{
+	"ffGeoJsonUrl": "http://freifunk.net/map/ffGeoJson.json"
+}

--- a/feed.php
+++ b/feed.php
@@ -35,17 +35,14 @@ foreach($geofeatures as $feature)
 		foreach($feature['properties']['feeds'] as $feed )
 		{
 			if ( ! empty($feed['category']) && $feed['category'] == $category && !empty($feed['type']) && $feed['type'] == "rss" ) {
-				array_push($feeds, array($feed['url'],$feature['properties']['name'], $feature['properties']['url']))  ;
+				$feeds[$feature['properties']['shortname']] = array($feed['url'],$feature['properties']['name'], $feature['properties']['url']);
 			}
 		}
 	}
 }
 
-
-
 // set the header type
 header("Content-type: text/xml");
-
 // set an arbitrary feed date
 $feed_date = date("r", mktime(10,0,0,9,8,2010));
 
@@ -53,5 +50,5 @@ $feed_date = date("r", mktime(10,0,0,9,8,2010));
 $MergedRSS = new MergedRSS($feeds, "Fossasia Community Feeds", "http://www.fossasia.net/", "This the merged RSS feed of RSS feeds of our community", $feed_date);
 
 //Export the first 10 items to screen
-$MergedRSS->export(false, true, 29);
+$MergedRSS->export(false, true, 1, $_GET['source']);
 

--- a/feed.php
+++ b/feed.php
@@ -43,6 +43,7 @@ foreach($geofeatures as $feature)
 
 // set the header type
 header("Content-type: text/xml");
+header('Access-Control-Allow-Origin: *');
 // set an arbitrary feed date
 $feed_date = date("r", mktime(10,0,0,9,8,2010));
 
@@ -50,5 +51,5 @@ $feed_date = date("r", mktime(10,0,0,9,8,2010));
 $MergedRSS = new MergedRSS($feeds, "Fossasia Community Feeds", "http://www.fossasia.net/", "This the merged RSS feed of RSS feeds of our community", $feed_date);
 
 //Export the first 10 items to screen
-$MergedRSS->export(false, true, 1, $_GET['source']);
+$MergedRSS->export(false, true, (array_key_exists('limit', $_GET) ? $_GET['limit'] : 1), $_GET['source']);
 

--- a/feed.php
+++ b/feed.php
@@ -7,7 +7,9 @@ if ( ! empty($_GET["category"]) ) {
 	$category = "blog";
 }
 
-$communities = "http://api.fossasia.net/ffGeoJson.json";
+$configs = file_get_contents("config.json");
+$configs = json_decode($configs, true);
+$communities = $configs['ffGeoJsonUrl'];
 
 //load combined api file
 $api = file_get_contents($communities);

--- a/mergedrss.php
+++ b/mergedrss.php
@@ -32,12 +32,16 @@ class MergedRSS {
 	}
 
 	// exports the data as a returned value and/or outputted to the screen
-	public function export($return_as_string = true, $output = false, $limit = null) { 
+	public function export($return_as_string = true, $output = false, $limit = null, $community = 'all') {
 		// initialize a combined item array for later
 		$items = array();	
 
 		// loop through each feed
-		foreach ($this->myFeeds as $feed_array) {
+		foreach ($this->myFeeds as $key => $feed_array) {
+			if ($community !== 'all' && $key !== $community) {
+				continue;
+			}
+
 			$feed_url = $feed_array[0];
 			// determine my cache file name.  for now i assume they're all kept in a file called "cache"
 			$cache_file = "cache/" . $this->__create_feed_key($feed_url);


### PR DESCRIPTION
Turn feed.php to a service with support for parameter `source` and `limit`.

* `source` : community filter. `source=all` will alow feeds from all communities
* `limit` : maximum number of blog feeds in response.

This service is used by the community map to display blog posts of each communities. C.f. https://github.com/fossasia/api.fossasia.net/issues/44

TODO : 

* [ ] use jsonp instead of `header('Access-Control-Allow-Origin: *');` to allow cross origin access to `feed.php`

           
           