### PR TITLE
use jsonp instead to allow cross origin access to feed.php

### DIFF
--- a/JsonpHelper.php
+++ b/JsonpHelper.php
@@ -1,0 +1,33 @@
+<?php
+class JsonpHelper {
+
+	private static function is_valid_callback($subject)
+	{
+	    $identifier_syntax
+	      = '/^[$_\p{L}][$_\p{L}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\x{200C}\x{200D}]*+$/u';
+
+	    $reserved_words = array('break', 'do', 'instanceof', 'typeof', 'case',
+	      'else', 'new', 'var', 'catch', 'finally', 'return', 'void', 'continue', 
+	      'for', 'switch', 'while', 'debugger', 'function', 'this', 'with', 
+	      'default', 'if', 'throw', 'delete', 'in', 'try', 'class', 'enum', 
+	      'extends', 'super', 'const', 'export', 'import', 'implements', 'let', 
+	      'private', 'public', 'yield', 'interface', 'package', 'protected', 
+	      'static', 'null', 'true', 'false');
+
+	    return preg_match($identifier_syntax, $subject)
+	        && ! in_array(mb_strtolower($subject, 'UTF-8'), $reserved_words);
+	}
+
+	public static function outputXML($string) {
+		# JSON if no callback
+		if( ! isset($_GET['callback']) )
+		    exit($string);
+		$string = str_replace("\n", " ", str_replace("'", '"', $string));
+		# JSONP if valid callback
+		if(JsonpHelper::is_valid_callback($_GET['callback']))
+		    exit("{$_GET['callback']}('$string')");
+
+		# Otherwise, bad request
+		header('status: 400 Bad Request', true, 400);
+	}
+}

--- a/feed.php
+++ b/feed.php
@@ -1,6 +1,6 @@
 <?php
 include_once("mergedrss.php");
-
+include_once("JsonpHelper.php");
 if ( ! empty($_GET["category"]) ) {
 	$category = $_GET["category"];
 } else {
@@ -45,7 +45,6 @@ foreach($geofeatures as $feature)
 
 // set the header type
 header("Content-type: text/xml");
-header('Access-Control-Allow-Origin: *');
 // set an arbitrary feed date
 $feed_date = date("r", mktime(10,0,0,9,8,2010));
 
@@ -53,5 +52,6 @@ $feed_date = date("r", mktime(10,0,0,9,8,2010));
 $MergedRSS = new MergedRSS($feeds, "Fossasia Community Feeds", "http://www.fossasia.net/", "This the merged RSS feed of RSS feeds of our community", $feed_date);
 
 //Export the first 10 items to screen
-$MergedRSS->export(false, true, (array_key_exists('limit', $_GET) ? $_GET['limit'] : 1), $_GET['source']);
+$result = $MergedRSS->export(true, false, (array_key_exists('limit', $_GET) ? $_GET['limit'] : 1), $_GET['source']);
 
+JsonpHelper::outputXML($result);


### PR DESCRIPTION
#3 : To return xml as string param of callback function, following conversions are needed :

* convert all double quotes " to simple quotes '
* replace end of line by a space
